### PR TITLE
Add installation and usage sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,67 @@
 
 Core for electronic invoicing pre-validation - DIAN UBL 2.1.
 
-# UBL 2.1 DIAN DETALLE
+## Overview / Resumen
+Paquete para facturación electrónica en Colombia.
 
-Paquete para facturacion electronica Colombia
-
-
-# Tags
-* 1: Contiene pruebas válidas con el token de seguridad binario (SOAP) y la firma XAdES (XML) con los algoritmos sha1, sha256 y sha512.
-* 2: Contiene las plantillas principales para el consumo del servicio web, requiere curl como una dependencia.
+## Tags
+* 1: Contiene pruebas válidas con el token de seguridad binario (SOAP) y la firma XAdES (XML) con los algoritmos SHA1, SHA256 y SHA512.
+* 2: Contiene las plantillas principales para el consumo del servicio web, requiere `curl` como dependencia.
 * 3: Se soluciona el error de canonización.
 * 4: Contiene pruebas válidas para el envío de notas de crédito y el cálculo del CUDE.
 * 5: Licencia LGPL.
 * 6: Contiene pruebas válidas para el envío de notas de débito y el nombre del documento estándar.
 
-# Funciones
+## Features / Funciones
 * Firma de documentos
-* Envió asincrono
+* Envío asíncrono
 * Consulta de estado por zipkey
 * Consulta de estado por cufe
 * Consulta de rangos de numeración
-* Envió de set de pruebas asíncrono
+* Envío de set de pruebas asíncrono
 
+## Requirements / Requisitos
+- PHP 5.4 o superior
+- Extensiones: dom, xml, curl, libxml, openssl y xmlwriter
+- [Composer](https://getcomposer.org/)
 
-# Resources
+## Installation / Instalación
+Use Composer para instalar la librería:
 
+```bash
+composer require ubl21dian/torresoftware
+```
 
-# Actualizacion 
+## Basic usage / Uso básico
 
+```php
+<?php
+require 'vendor/autoload.php';
 
+use ubl21dian\Templates\SOAP\GetStatus;
+
+$certPath = '/ruta/al/certificado.p12';
+$password = 'su_clave';
+$trackId  = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$getStatus = new GetStatus($certPath, $password);
+$getStatus->trackId = $trackId;
+
+$client = $getStatus->signToSend();
+echo $client->getResponse();
+```
+
+## Running tests / Ejecutar pruebas
+
+Instale las dependencias de desarrollo y ejecute PHPUnit:
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+## Resources / Recursos
+- [DIAN - Facturación Electrónica](https://www.dian.gov.co/)
+
+## License / Licencia
+LGPL-3.0


### PR DESCRIPTION
## Summary
- document Composer installation
- add basic usage example
- explain how to run the test suite
- describe requirements and add useful links

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68405c728bf083239f797f930a62ccb1